### PR TITLE
Fix building with gcc10

### DIFF
--- a/si_types.h
+++ b/si_types.h
@@ -113,7 +113,7 @@ struct service {
   uint32_t logical_channel_number;
   uint8_t  running;
   void   * priv;
-} service_t, * p_service_t;
+};
 
 /*******************************************************************************
 /* transponder type.
@@ -204,7 +204,7 @@ struct transponder {
   char * signal_strength_unit;
   double signal_quality;
   char * signal_quality_unit;
-} __attribute__((packed))  transponder_t, * p_transponder_t;
+} __attribute__((packed));
 
 /*******************************************************************************
 /* satellite channel routing type.


### PR DESCRIPTION
Currently t2scan can't be build with gcc10 due to https://gcc.gnu.org/gcc-10/porting_to.html#common This can be easily fixed with removing with variable declarations nobody uses. Afaik, they were meant to be type definitions but due to a typos they ended variable declarations.