### PR TITLE
t2scan: fix -std=c23 build failure

### DIFF
--- a/char-coding.h
+++ b/char-coding.h
@@ -31,7 +31,7 @@ int get_codepage_index(const char * codepage);
 /*
  * set the default charset that is used if a string does not include a charset definition in the first byte
  */
-void set_char_coding_default_charset();
+void set_char_coding_default_charset(char *);
 
 /*
  * reset default charset to the reset_to_charset

--- a/emulate.c
+++ b/emulate.c
@@ -199,7 +199,7 @@ int  em_getproperty(struct dtv_properties * cmdseq) {
 }
 
 
-void em_lnb(int high_band, uint32_t high_val, uint32_t low_val) {
+void em_lnb(_Bool high_band, uint32_t high_val, uint32_t low_val) {
   em_device.highband = high_band;
   em_device.lnb_low = low_val;
   em_device.lnb_high = high_val;

--- a/emulate.h
+++ b/emulate.h
@@ -17,7 +17,7 @@ void em_dvbapi(uint16_t * flags);
 int  em_setproperty(struct dtv_properties * cmdseq);
 int  em_getproperty(struct dtv_properties * cmdseq);
 int  em_status(fe_status_t * status);
-void em_lnb(bool high_band, uint32_t high_val, uint32_t low_val);
+void em_lnb(_Bool high_band, uint32_t high_val, uint32_t low_val);
 void em_polarization(uint8_t p);
 
 //--------------------------------------------------

--- a/tools.h
+++ b/tools.h
@@ -31,10 +31,12 @@
 /*******************************************************************************
 /* common typedefs && logging.
  ******************************************************************************/
-#ifndef bool
-  typedef int bool;
-  #define false 0
-  #define true  !(false)
+#if defined __STDC__ && defined __STDC_VERSION__ && __STDC_VERSION__ <= 201710L
+  #ifndef bool
+    typedef int bool;
+    #define false 0
+    #define true  !(false)
+  #endif
 #endif
 
 #define min(a,b)  (b<a?b:a)


### PR DESCRIPTION
gcc-15 switched to -std=c23 by default:

    https://gcc.gnu.org/git/?p=gcc.git;a=commitdiff;h=55e3bd376b2214e200fa76d12b67ff259b06c212

As a result `t2scan` fails the build so only typedef int bool for __STDC_VERSION__ <= 201710L (C17)

    ../tools.h:35:15: error: two or more data types in declaration specifiers
       35 |   typedef int bool;
          |               ^~~~